### PR TITLE
Bug-Fix: The lpstat output was not correctly parsed

### DIFF
--- a/usr/local/lib/zabbix/externalscripts/discover_cups_printers.pl
+++ b/usr/local/lib/zabbix/externalscripts/discover_cups_printers.pl
@@ -1,5 +1,5 @@
 #!/bin/bash
-printers=`lpstat -p | grep printer | cut -f2 -d ' '`
+printers=`lpstat -p | grep "^printer" | cut -f2 -d ' '`
 # printers=$(($printers-1))
 isfirst=1
 echo "{"


### PR DESCRIPTION
the previous edition also recognized warnings/errors on the printer as a new printer
